### PR TITLE
Make link to Github visible.

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -118,11 +118,10 @@
           <option>Rotational</option>
         </select>
       </div>
-
-    </div>
-
-    <div style='text-align:center'>
-      <a href='https://github.com/PeterReid/tagpro-map-editor'>[Source]</a>
+  
+      <div style='text-align:center'>
+        <a href='https://github.com/PeterReid/tagpro-map-editor'>[Source]</a>
+      </div>
     </div>
 
   </div>


### PR DESCRIPTION
It was hidden beneath the editor for me. This puts it below the tools.
